### PR TITLE
enable use of list specific actions

### DIFF
--- a/.changeset/clever-kiwis-impress.md
+++ b/.changeset/clever-kiwis-impress.md
@@ -1,0 +1,17 @@
+---
+'@keystonejs/app-admin-ui': minor
+---
+
+Enable use of ui hooks for specific List page. To use list specific hooks, create them in the list name key
+
+```js
+module.exports = {
+    // hooks for all lists
+    itemHeaderActions: ActionsForAllPage,
+    listHeaderActions: ActionsForAllPage,
+    Post: {
+        itemHeaderActions: ActionsForPostListPageOnly,
+        listHeaderActions: ActionsForPostPageOnly,
+    },
+}
+```

--- a/packages/app-admin-ui/client/pages/Item/ItemTitle.js
+++ b/packages/app-admin-ui/client/pages/Item/ItemTitle.js
@@ -23,7 +23,7 @@ const Container = ({ children }) => {
 
 export const ItemTitle = memo(function ItemTitle({ titleText }) {
   const { list } = useList();
-  const { itemHeaderActions } = useUIHooks();
+  const { itemHeaderActions } = useUIHooks(list.key);
   return (
     <Container>
       <PageTitle>{titleText}</PageTitle>

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -45,7 +45,7 @@ export function ListLayout(props) {
   const [sortBy, handleSortChange] = useListSort();
   const [selectedItems, onSelectChange] = useListSelect(items);
 
-  const { listHeaderActions } = useUIHooks();
+  const { listHeaderActions } = useUIHooks(list.key);
 
   // Misc.
   // ------------------------------

--- a/packages/app-admin-ui/client/providers/Hooks.js
+++ b/packages/app-admin-ui/client/providers/Hooks.js
@@ -5,7 +5,10 @@ const defaultHooks = {
   // Intentionally empty for now
 };
 
-export const useUIHooks = () => useContext(HooksContext);
+export const useUIHooks = key => {
+  const hooks = useContext(HooksContext);
+  return { ...hooks, ...(hooks[key] || {}) };
+};
 export const HooksProvider = ({ hooks, children }) => {
   return (
     <HooksContext.Provider value={{ ...defaultHooks, ...hooks }}>{children}</HooksContext.Provider>


### PR DESCRIPTION
@MadeByMike 

this is exactly as in - https://github.com/keystonejs/keystone/pull/2494

advantage is that it can help create actions for all list as well as specific list. 

if we do not have this then list specific hook has to be detected as:
```js
export const ListHeaderActions = () => {
  const { list } = useList();
  const setSearch = useListModifier(list.key);
  return (
    <FlexGroup align="space-between">
      {list.key === 'Post' ? (
        <>
          <MyActionForPostListHeader />
          <IconButton
            appearance="primary"
            icon={PlusIcon}
            onClick={() => setSearch('...search parameters')}
            >
            Need Post Approval
          </IconButton>
          <CreateItem />
        </> ) : (
          <CreateItem />
        )}
    </FlexGroup>
  );
};
```
with this PR
```js
export const ListHeaderActions = () => {
  const { list } = useList();
  const setSearch = useListModifier(list.key);
  return (
    <FlexGroup align="space-between">
        <OtherHeaderActionsForAllLists />
        <IconButton
          appearance="primary"
          icon={PlusIcon}
          onClick={() => setSearch('...search parameters')}
          >
          Need Post Approval
        </IconButton>
        <CreateItem />
    </FlexGroup>
  );
};
```

here is how you would add list specific hook
```js
module.exports = {
    // hooks for all lists
    itemHeaderActions: ActionsForAllPage,
    listHeaderActions: ActionsForAllPage,
    Post: {
        // hooks for Pst list only
        itemHeaderActions: ActionsForPostListPageOnly,
        listHeaderActions: ActionsForPostPageOnly,
    },
}
```

I have had situation where I added many list header actions which would be targeted to specific list only out of 10+ list in keystone. reason being most the action was pre-canned filter which you will be using with specific list.